### PR TITLE
Update to expose CT3 of EDDI

### DIFF
--- a/custom_components/myenergi/sensor.py
+++ b/custom_components/myenergi/sensor.py
@@ -305,7 +305,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
             for key in device.ct_keys:
                 sensors.append(MyenergiCTEnergySensor(coordinator, device, entry, key))
         # Zappi and harvi
-        if device.kind in [ZAPPI, HARVI]:
+        if device.kind in [ZAPPI, EDDI, HARVI]:
             sensors.append(
                 MyenergiSensor(
                     coordinator,


### PR DESCRIPTION
Eddi have three CT entries, CT1 is internal load then CT2 and CT3 are the external clamps

Will need https://github.com/CJNE/pymyenergi/pull/4 to be merged and the dependency version updated in manifest 