### PR TITLE
Add libbi support

### DIFF
--- a/custom_components/myenergi/const.py
+++ b/custom_components/myenergi/const.py
@@ -3,7 +3,7 @@
 NAME = "myenergi"
 DOMAIN = "myenergi"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "0.0.23"
+VERSION = "0.0.24"
 
 ATTRIBUTION = "Data provided by myenergi"
 ISSUE_URL = "https://github.com/CJNE/ha-myenergi/issues"

--- a/custom_components/myenergi/manifest.json
+++ b/custom_components/myenergi/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/cjne/ha-myenergi",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/cjne/ha-myenergi/issues",
-  "requirements": ["pymyenergi==0.0.27"],
-  "version": "0.0.23"
+  "requirements": ["pymyenergi==0.0.28"],
+  "version": "0.0.24"
 }

--- a/custom_components/myenergi/manifest.json
+++ b/custom_components/myenergi/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/cjne/ha-myenergi",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/cjne/ha-myenergi/issues",
-  "requirements": ["pymyenergi==0.0.28"],
+  "requirements": ["pymyenergi==0.0.29"],
   "version": "0.0.24"
 }

--- a/custom_components/myenergi/number.py
+++ b/custom_components/myenergi/number.py
@@ -22,6 +22,8 @@ async def async_setup_entry(hass, entry, async_add_devices):
         elif device.kind == "eddi":
             devices.append(HeaterPriorityNumber(coordinator, device, entry))
             devices.append(DevicePriorityNumber(coordinator, device, entry))
+        elif device.kind == "libbi":
+            devices.append(DevicePriorityNumber(coordinator, device, entry))
     async_add_devices(devices)
 
 

--- a/custom_components/myenergi/sensor.py
+++ b/custom_components/myenergi/sensor.py
@@ -501,7 +501,6 @@ async def async_setup_entry(hass, entry, async_add_devices):
                         "state_of_charge",
                         DEVICE_CLASS_BATTERY,
                         PERCENTAGE,
-                        ENTITY_CATEGORY_DIAGNOSTIC,
                     ),
                 )
             )
@@ -567,18 +566,6 @@ async def async_setup_entry(hass, entry, async_add_devices):
                     )
                 )
             )
-            """ expose this temporarily (it's mapped to operating mode)"""
-            sensors.append(
-                MyenergiSensor(
-                    coordinator,
-                    device,
-                    entry,
-                    create_meta(
-                        f"Local mode",
-                        "local_mode",
-                    )
-                )
-            )
             sensors.append(
                 MyenergiSensor(
                     coordinator,
@@ -594,6 +581,86 @@ async def async_setup_entry(hass, entry, async_add_devices):
                     )
                 )
             )
+            sensors.append(
+                MyenergiSensor(
+                    coordinator,
+                    device,
+                    entry,
+                    create_meta(
+                        f"Grid import today",
+                        "grid_import",
+                        DEVICE_CLASS_ENERGY,
+                        ENERGY_KILO_WATT_HOUR,
+                        None,
+                        None,
+                        STATE_CLASS_TOTAL_INCREASING,
+                    )
+                )
+            )
+            sensors.append(
+                MyenergiSensor(
+                    coordinator,
+                    device,
+                    entry,
+                    create_meta(
+                        f"Grid export today",
+                        "grid_export",
+                        DEVICE_CLASS_ENERGY,
+                        ENERGY_KILO_WATT_HOUR,
+                        None,
+                        None,
+                        STATE_CLASS_TOTAL_INCREASING,
+                    )
+                )
+            )
+            sensors.append(
+                MyenergiSensor(
+                    coordinator,
+                    device,
+                    entry,
+                    create_meta(
+                        f"Battery charge today",
+                        "battery_charge",
+                        DEVICE_CLASS_ENERGY,
+                        ENERGY_KILO_WATT_HOUR,
+                        None,
+                        None,
+                        STATE_CLASS_TOTAL_INCREASING,
+                    )
+                )
+            )
+            sensors.append(
+                MyenergiSensor(
+                    coordinator,
+                    device,
+                    entry,
+                    create_meta(
+                        f"Battery discharge today",
+                        "battery_discharge",
+                        DEVICE_CLASS_ENERGY,
+                        ENERGY_KILO_WATT_HOUR,
+                        None,
+                        None,
+                        STATE_CLASS_TOTAL_INCREASING,
+                    )
+                )
+            )
+            sensors.append(
+                MyenergiSensor(
+                    coordinator,
+                    device,
+                    entry,
+                    create_meta(
+                        f"Solar generation today",
+                        "generated",
+                        DEVICE_CLASS_ENERGY,
+                        ENERGY_KILO_WATT_HOUR,
+                        None,
+                        None,
+                        STATE_CLASS_TOTAL_INCREASING,
+                    )
+                )
+            )
     async_add_devices(sensors)
 
 
@@ -606,7 +673,7 @@ class MyenergiHubSensor(MyenergiHub, SensorEntity):
     @property
     def unique_id(self):
         """Return a unique ID to use for this entity."""
-        return f"{self.config_entry.entry_id}-{self.coordinator.client.serial_number}-{self.meta['prop_name']}"
+        return f"{self.config_entry.entry_id}-hub-{self.coordinator.client.serial_number}-{self.meta['prop_name']}"
 
     @property
     def name(self):

--- a/custom_components/myenergi/sensor.py
+++ b/custom_components/myenergi/sensor.py
@@ -8,6 +8,7 @@ from homeassistant.const import DEVICE_CLASS_ENERGY
 from homeassistant.const import DEVICE_CLASS_POWER
 from homeassistant.const import DEVICE_CLASS_TEMPERATURE
 from homeassistant.const import DEVICE_CLASS_VOLTAGE
+from homeassistant.const import DEVICE_CLASS_BATTERY
 from homeassistant.const import ELECTRIC_POTENTIAL_VOLT
 from homeassistant.const import ENERGY_KILO_WATT_HOUR
 from homeassistant.const import FREQUENCY_HERTZ
@@ -20,6 +21,7 @@ from pymyenergi import CT_LOAD
 from pymyenergi import EDDI
 from pymyenergi import HARVI
 from pymyenergi import ZAPPI
+from pymyenergi import LIBBI
 
 from .const import DOMAIN
 from .entity import MyenergiEntity
@@ -29,6 +31,8 @@ ENTITY_CATEGORY_DIAGNOSTIC = EntityCategory.DIAGNOSTIC
 
 ICON_VOLT = "mdi:lightning-bolt"
 ICON_FREQ = "mdi:sine-wave"
+ICON_POWER = "mdi:flash"
+ICON_HOME_BATTERY = "mdi:home-battery"
 
 
 def create_meta(
@@ -486,6 +490,110 @@ async def async_setup_entry(hass, entry, async_add_devices):
                         ),
                     )
                 )
+        elif device.kind == LIBBI:
+            sensors.append(
+                MyenergiSensor(
+                    coordinator,
+                    device,
+                    entry,
+                    create_meta(
+                        f"SoC",
+                        "state_of_charge",
+                        DEVICE_CLASS_BATTERY,
+                        PERCENTAGE,
+                        ENTITY_CATEGORY_DIAGNOSTIC,
+                    ),
+                )
+            )
+            sensors.append(
+                MyenergiSensor(
+                    coordinator,
+                    device,
+                    entry,
+                    create_meta(
+                        f"Voltage",
+                        "supply_voltage",
+                        DEVICE_CLASS_VOLTAGE,
+                        ELECTRIC_POTENTIAL_VOLT,
+                        ENTITY_CATEGORY_DIAGNOSTIC,
+                        ICON_VOLT,
+                        STATE_CLASS_MEASUREMENT,
+                    ),
+                )
+            )
+            sensors.append(
+                MyenergiSensor(
+                    coordinator,
+                    device,
+                    entry,
+                    create_meta(
+                        f"Frequency",
+                        "supply_frequency",
+                        None,
+                        FREQUENCY_HERTZ,
+                        ENTITY_CATEGORY_DIAGNOSTIC,
+                        ICON_FREQ,
+                        STATE_CLASS_MEASUREMENT,
+                    ),
+                )
+            )
+            sensors.append(
+                MyenergiSensor(
+                    coordinator,
+                    device,
+                    entry,
+                    create_meta(
+                        f"Inverter size",
+                        "inverter_size",
+                        None,
+                        ENERGY_KILO_WATT_HOUR,
+                        ENTITY_CATEGORY_DIAGNOSTIC,
+                        ICON_POWER,
+                    ),
+                )
+            )
+            sensors.append(
+                MyenergiSensor(
+                    coordinator,
+                    device,
+                    entry,
+                    create_meta(
+                        f"Battery size",
+                        "battery_size",
+                        None,
+                        ENERGY_KILO_WATT_HOUR,
+                        ENTITY_CATEGORY_DIAGNOSTIC,
+                        ICON_POWER,
+                    )
+                )
+            )
+            """ expose this temporarily (it's mapped to operating mode)"""
+            sensors.append(
+                MyenergiSensor(
+                    coordinator,
+                    device,
+                    entry,
+                    create_meta(
+                        f"Local mode",
+                        "local_mode",
+                    )
+                )
+            )
+            sensors.append(
+                MyenergiSensor(
+                    coordinator,
+                    device,
+                    entry,
+                    create_meta(
+                        f"Status",
+                        "status",
+                        None,
+                        None,
+                        None,
+                        ICON_HOME_BATTERY,
+                    )
+                )
+            )
     async_add_devices(sensors)
 
 


### PR DESCRIPTION
This PR add libbi support to the HA component. (closes #395)
The integration now exposes libbi's:
- cumulative energy sensors (grid export/import, solar generation, battery charge/discharge)
- various CTs (grid, dc pv)
- other diagnostic data (inverter size, battery size)
You can also change the operating mode (normal/stopped) and set the device priority.

I have also included a fix for #375, which is caused by myenergi devices being used a virtual hubs.