### PR TITLE
493 unlock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ pythonenv*
 venv
 .venv
 .direnv
+.vscode/settings.json
+.devcontainer/configuration.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@ pythonenv*
 venv
 .venv
 .direnv
-.vscode/settings.json
-.devcontainer/configuration.yaml
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ pythonenv*
 venv
 .venv
 .direnv
-

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ It will create HA devices depending on what you have installed:
   - Service to start boost (provide boost amount in kWh as parameter)
   - Service to start smart boost (provide boost amount in kWh and desired finished time as paramters)
   - Service to stop boost
+  - Service to unlock the Zappi
 
 - Eddi
 

--- a/custom_components/myenergi/entity.py
+++ b/custom_components/myenergi/entity.py
@@ -70,6 +70,12 @@ class MyenergiEntity(CoordinatorEntity):
         await self.device.stop_boost()
         self.schedule_update_ha_state()
 
+    async def unlock(self) -> None:
+        _LOGGER.debug("unlock called")
+        """Unlock"""
+        await self.device.unlock()
+        self.schedule_update_ha_state()
+
 
 class MyenergiHub(CoordinatorEntity):
     def __init__(self, coordinator, config_entry, meta):

--- a/custom_components/myenergi/select.py
+++ b/custom_components/myenergi/select.py
@@ -60,6 +60,11 @@ async def async_setup_entry(hass, entry, async_add_devices):
                 {},
                 "stop_boost",
             )
+            platform.async_register_entity_service(
+                "myenergi_unlock",
+                {},
+                "unlock",
+            )
             devices.append(ZappiChargeModeSelect(coordinator, device, entry))
         elif device.kind == "eddi":
             platform.async_register_entity_service(

--- a/custom_components/myenergi/services.yaml
+++ b/custom_components/myenergi/services.yaml
@@ -71,3 +71,11 @@ myenergi_stop_boost:
       model: Zappi
     entity:
       domain: select
+myenergi_unlock:
+  name: Unlock
+  description: Unlock
+  target:
+    device:
+      model: Zappi
+    entity:
+      domain: select

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,3 +145,10 @@ def mock_zappi_stop_boost():
     """Return a mocked Zappi object."""
     with patch("pymyenergi.client.Zappi.stop_boost") as stop_boost:
         yield stop_boost
+
+
+@pytest.fixture
+def mock_zappi_unlock():
+    """Return a mocked Zappi object."""
+    with patch("pymyenergi.client.Zappi.unlock") as unlock:
+        yield unlock

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -90,3 +90,23 @@ async def test_stop_boost(
     assert mock_zappi_stop_boost.call_count == 0
     await hass.async_block_till_done()
     assert mock_zappi_stop_boost.call_count == 1
+
+
+async def test_unlock(
+    hass: HomeAssistant, mock_zappi_unlock: MagicMock
+) -> None:
+    """Verify device information includes expected details."""
+
+    await setup_mock_myenergi_config_entry(hass)
+
+    await hass.services.async_call(
+        "myenergi",
+        "myenergi_unlock",
+        {
+            ATTR_ENTITY_ID: TEST_ZAPPI_SELECT_CHARGE_MODE,
+        },
+        blocking=False,
+    )
+    assert mock_zappi_unlock.call_count == 0
+    await hass.async_block_till_done()
+    assert mock_zappi_unlock.call_count == 1


### PR DESCRIPTION
Closes https://github.com/CJNE/ha-myenergi/issues/493

This change exposes the unlock call available in the pymyenergi project for the zappi.

This is my first HA component development, so hope I haven't missed anything. I ran the tests and they all seemed to pass.

I also tested the functionality by manually updating the code in my local environment and it work successfully i.e. - I could unlock my Zappi from HA.  

