### PR TITLE
Add zappi phase setting select

### DIFF
--- a/custom_components/myenergi/select.py
+++ b/custom_components/myenergi/select.py
@@ -11,6 +11,8 @@ from .entity import MyenergiEntity
 
 LIBBI_MODE_NAMES = {0: "Stopped", 1: "Normal", 5: "Export"}
 
+ZAPPI_PHASE_SETTING = ["1", "3", "auto"]
+
 ATTR_BOOST_AMOUNT = "amount"
 ATTR_BOOST_TIME = "time"
 ATTR_BOOST_TARGET = "target"
@@ -66,6 +68,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
                 "unlock",
             )
             devices.append(ZappiChargeModeSelect(coordinator, device, entry))
+            devices.append(ZappiPhaseSettingSelect(coordinator, device, entry))
         elif device.kind == "eddi":
             platform.async_register_entity_service(
                 "myenergi_eddi_boost",
@@ -113,26 +116,38 @@ class EddiOperatingModeSelect(MyenergiEntity, SelectEntity):
         return EDDI_MODES
 
 
+class ZappiPhaseSettingSelect(MyenergiEntity, SelectEntity):
+    """myenergi Sensor class."""
+
+    def __init__(self, coordinator, device, config_entry):
+        super().__init__(coordinator, device, config_entry)
+        self._attr_icon = "mdi:ev-station"
+        self._attr_unique_id = f"{self.config_entry.entry_id}-{self.device.serial_number}-phase_setting_select"
+        self._attr_name = f"myenergi {self.device.name} Phase Setting"
+        self._attr_translation_key = "phase_setting"
+        self._attr_options = ZAPPI_PHASE_SETTING
+
+    @property
+    def current_option(self):
+        """Return the state of the sensor."""
+        return self.device.num_phases
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        await self.device.set_phase_setting(option)
+        self.async_schedule_update_ha_state()
+
+
 class ZappiChargeModeSelect(MyenergiEntity, SelectEntity):
     """myenergi Sensor class."""
 
     def __init__(self, coordinator, device, config_entry):
         super().__init__(coordinator, device, config_entry)
-
-    @property
-    def unique_id(self):
-        """Return a unique ID to use for this entity."""
-        return f"{self.config_entry.entry_id}-{self.device.serial_number}-charge_mode"
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return f"myenergi {self.device.name} Charge Mode"
-
-    @property
-    def icon(self):
-        """Return the icon of the select."""
-        return "mdi:ev-station"
+        self._attr_icon = "mdi:ev-station"
+        self._attr_unique_id = f"{self.config_entry.entry_id}-{self.device.serial_number}-charge_mode"
+        self._attr_name = f"myenergi {self.device.name} Charge Mode"
+        self._attr_translation_key = "phase_setting"
+        self._attr_options = CHARGE_MODES[1:]
 
     @property
     def current_option(self):
@@ -143,10 +158,6 @@ class ZappiChargeModeSelect(MyenergiEntity, SelectEntity):
         """Change the selected option."""
         await self.device.set_charge_mode(option)
         self.async_schedule_update_ha_state()
-
-    @property
-    def options(self):
-        return CHARGE_MODES[1:]
 
 
 class LibbiOperatingModeSelect(MyenergiEntity, SelectEntity):

--- a/custom_components/myenergi/select.py
+++ b/custom_components/myenergi/select.py
@@ -144,7 +144,9 @@ class ZappiChargeModeSelect(MyenergiEntity, SelectEntity):
     def __init__(self, coordinator, device, config_entry):
         super().__init__(coordinator, device, config_entry)
         self._attr_icon = "mdi:ev-station"
-        self._attr_unique_id = f"{self.config_entry.entry_id}-{self.device.serial_number}-charge_mode"
+        self._attr_unique_id = (
+            f"{self.config_entry.entry_id}-{self.device.serial_number}-charge_mode"
+        )
         self._attr_name = f"myenergi {self.device.name} Charge Mode"
         self._attr_translation_key = "phase_setting"
         self._attr_options = CHARGE_MODES[1:]

--- a/custom_components/myenergi/translations/en.json
+++ b/custom_components/myenergi/translations/en.json
@@ -30,10 +30,10 @@
   "entity": {
     "select": {
       "phase_setting": {
-        "state" : {
-          "1" : "1",
-          "3" : "3",
-          "auto" : "Automatic"
+        "state": {
+          "1": "1",
+          "3": "3",
+          "auto": "Automatic"
         }
       }
     }

--- a/custom_components/myenergi/translations/en.json
+++ b/custom_components/myenergi/translations/en.json
@@ -26,5 +26,16 @@
         }
       }
     }
+  },
+  "entity": {
+    "select": {
+      "phase_setting": {
+        "state" : {
+          "1" : "1",
+          "3" : "3",
+          "auto" : "Automatic"
+        }
+      }
+    }
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,12 @@ def mock_zappi_set_charge_mode():
 
 
 @pytest.fixture
+def mock_zappi_set_phase_setting():
+    """Return a mocked Zappi object."""
+    with patch("pymyenergi.client.Zappi.set_phase_setting") as phase_setting:
+        yield phase_setting
+
+@pytest.fixture
 def mock_eddi_set_operating_mode():
     """Return a mocked Eddi object."""
     with patch("pymyenergi.client.Eddi.set_operating_mode") as op_mode:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,7 @@ def mock_zappi_set_phase_setting():
     with patch("pymyenergi.client.Zappi.set_phase_setting") as phase_setting:
         yield phase_setting
 
+
 @pytest.fixture
 def mock_eddi_set_operating_mode():
     """Return a mocked Eddi object."""

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from . import setup_mock_myenergi_config_entry
 
 TEST_ZAPPI_SELECT_CHARGE_MODE = "select.myenergi_test_zappi_1_charge_mode"
-TEST_ZAPPI_SELECT_PHASE_SETTING = "select.myenergi_test_zappi_1_phase_setting_select"
+TEST_ZAPPI_SELECT_PHASE_SETTING = "select.myenergi_test_zappi_1_phase_setting"
 TEST_EDDI_SELECT_OP_MODE = "select.myenergi_test_eddi_1_operating_mode"
 
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -36,7 +36,6 @@ async def test_zappi_select(
     mock_zappi_set_phase_setting.assert_called_with("1")
 
 
-
 async def test_zappi_phaseselect(
     hass: HomeAssistant, mock_zappi_set_charge_mode: MagicMock
 ) -> None:

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -10,10 +10,34 @@ from homeassistant.core import HomeAssistant
 from . import setup_mock_myenergi_config_entry
 
 TEST_ZAPPI_SELECT_CHARGE_MODE = "select.myenergi_test_zappi_1_charge_mode"
+TEST_ZAPPI_SELECT_PHASE_SETTING = "select.myenergi_test_zappi_1_phase_setting_select"
 TEST_EDDI_SELECT_OP_MODE = "select.myenergi_test_eddi_1_operating_mode"
 
 
 async def test_zappi_select(
+    hass: HomeAssistant, mock_zappi_set_phase_setting: MagicMock
+) -> None:
+    """Verify device information includes expected details."""
+
+    await setup_mock_myenergi_config_entry(hass)
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: TEST_ZAPPI_SELECT_PHASE_SETTING,
+            ATTR_OPTION: "1",
+        },
+        blocking=False,
+    )
+    assert mock_zappi_set_phase_setting.call_count == 0
+    await hass.async_block_till_done()
+    assert mock_zappi_set_phase_setting.call_count == 1
+    mock_zappi_set_phase_setting.assert_called_with("1")
+
+
+
+async def test_zappi_phaseselect(
     hass: HomeAssistant, mock_zappi_set_charge_mode: MagicMock
 ) -> None:
     """Verify device information includes expected details."""


### PR DESCRIPTION
Add support for zappi phase select, fixed #509 , depends on https://github.com/CJNE/pymyenergi/pull/35