### PR TITLE
async_setup_entry: migrate to new API

### DIFF
--- a/custom_components/myenergi/__init__.py
+++ b/custom_components/myenergi/__init__.py
@@ -54,9 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     for platform in PLATFORMS:
         if entry.options.get(platform, True):
             coordinator.platforms.append(platform)
-            hass.async_add_job(
-                hass.config_entries.async_forward_entry_setup(entry, platform)
-            )
+            await hass.config_entries.async_forward_entry_setups(entry, platform)
 
     entry.add_update_listener(async_reload_entry)
     return True


### PR DESCRIPTION
I think this is the right fix but I haven't worked out how to test against the dev image. Does a PR kick off CI?