### PR TITLE
Update __init__.py to support 2025 error

### DIFF
--- a/custom_components/myenergi/__init__.py
+++ b/custom_components/myenergi/__init__.py
@@ -11,7 +11,7 @@ from datetime import timedelta
 
 import homeassistant.util.dt as dt_util
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Config
+from homeassistant.core_config import Config  # Updated import for 2025.11
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.update_coordinator import UpdateFailed


### PR DESCRIPTION
Config was used from myenergi, this is a deprecated alias which will be removed in HA Core 2025.11. Use homeassistant.core_config.Config instead, please report it to the author of the 'myenergi' custom integration

https://github.com/CJNE/ha-myenergi/issues/602 