### PR TITLE
Smart boost sensor for amount, start hour and start minute

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ It will create HA devices depending on what you have installed:
   - Plug status sensor
   - Charger status sensor
   - Minumum green level number input; how much power must be sourced from green sources (local generation) to do diversion charging
+  - Smart boost start hour
+  - Smart boost start minute
+  - Smart boost amount; in kWh
   - Service to start boost (provide boost amount in kWh as parameter)
   - Service to start smart boost (provide boost amount in kWh and desired finished time as paramters)
   - Service to stop boost

--- a/custom_components/myenergi/sensor.py
+++ b/custom_components/myenergi/sensor.py
@@ -392,6 +392,43 @@ async def async_setup_entry(hass, entry, async_add_devices):
                         "mdi:ev-plug-type2",
                     ),
                 )
+            )            
+            sensors.append(
+                MyenergiSensor(
+                    coordinator,
+                    device,
+                    entry,
+                    create_meta(
+                        "Smart boost start hour", 
+                        "smart_boost_start_hour",
+                        None,
+                        None,
+                        None,
+                        "mdi:clock-fast"
+                    ),
+                )
+            )
+            sensors.append(
+                MyenergiSensor(
+                    coordinator,
+                    device,
+                    entry,
+                    create_meta(
+                        "Smart boost start minute", 
+                        "smart_boost_start_minute",
+                        None,
+                        None,
+                        None,
+                        "mdi:clock-fast"),
+                )
+            )
+            sensors.append(
+                MyenergiSensor(
+                    coordinator,
+                    device,
+                    entry,
+                    create_energy_meta("Smart boost amount", "smart_boost_amount"),
+                )
             )
 
             if device.ct4.name != "None":

--- a/custom_components/myenergi/sensor.py
+++ b/custom_components/myenergi/sensor.py
@@ -392,19 +392,19 @@ async def async_setup_entry(hass, entry, async_add_devices):
                         "mdi:ev-plug-type2",
                     ),
                 )
-            )            
+            )
             sensors.append(
                 MyenergiSensor(
                     coordinator,
                     device,
                     entry,
                     create_meta(
-                        "Smart boost start hour", 
+                        "Smart boost start hour",
                         "smart_boost_start_hour",
                         None,
                         None,
                         None,
-                        "mdi:clock-fast"
+                        "mdi:clock-fast",
                     ),
                 )
             )
@@ -414,12 +414,13 @@ async def async_setup_entry(hass, entry, async_add_devices):
                     device,
                     entry,
                     create_meta(
-                        "Smart boost start minute", 
+                        "Smart boost start minute",
                         "smart_boost_start_minute",
                         None,
                         None,
                         None,
-                        "mdi:clock-fast"),
+                        "mdi:clock-fast",
+                    ),
                 )
             )
             sensors.append(


### PR DESCRIPTION
To create some insights into the service of Smart Boost some data is available in the pymyenergi. This data is not available as sensors. The amount is setup as energy sensor, the rest was a as-is sensor.

If anyone has idea's to merge start hour and start minute into a time sensor, tips are more than welcome.