### PR TITLE
Add Sensors for Zappi - various lock statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ It will create HA devices depending on what you have installed:
   - Service to start smart boost (provide boost amount in kWh and desired finished time as paramters)
   - Service to stop boost
   - Service to unlock the Zappi
+  - Sensor for PIN Lock Status (This is not very useful in the real world)
+  - Sensor for Charge when Locked Status (This is the sensor that relates to the "unlock" service call and is the one you will want to use)
+  - Sensor for lock when plugged in status
+  - Sensor for lock when unplugged status
 
 - Eddi
 

--- a/custom_components/myenergi/binary_sensor.py
+++ b/custom_components/myenergi/binary_sensor.py
@@ -32,6 +32,58 @@ async def async_setup_entry(hass, entry, async_add_devices):
                     },
                 )
             )
+            sensors.append(
+                MyenergiBinarySensor(
+                    coordinator,
+                    device,
+                    entry,
+                    {
+                        "name": "Charge When Locked",
+                        "prop_name": "charge_when_locked",
+                        "icon": None,
+                        "attrs": {},
+                    },
+                )
+            )
+            sensors.append(
+                MyenergiBinarySensor(
+                    coordinator,
+                    device,
+                    entry,
+                    {
+                        "name": "Locked",
+                        "prop_name": "locked",
+                        "icon": None,
+                        "attrs": {},
+                    },
+                )
+            )
+            sensors.append(
+                MyenergiBinarySensor(
+                    coordinator,
+                    device,
+                    entry,
+                    {
+                        "name": "Lock when Plugged In",
+                        "prop_name": "lock_when_pluggedin",
+                        "icon": None,
+                        "attrs": {},
+                    },
+                )
+            )
+            sensors.append(
+                MyenergiBinarySensor(
+                    coordinator,
+                    device,
+                    entry,
+                    {
+                        "name": "Lock when Unplugged",
+                        "prop_name": "lock_when_unplugged",
+                        "icon": None,
+                        "attrs": {},
+                    },
+                )
+            )
         if device.kind == EDDI:
             sensors.append(
                 MyenergiBinarySensor(
@@ -88,3 +140,23 @@ class MyenergiBinarySensor(MyenergiEntity, BinarySensorEntity):
     def icon(self):
         """Return the icon of the sensor."""
         return self.meta["icon"]
+
+    @property
+    def locked(self):
+       """Lock status"""
+       return self._data.get("lck", 0) >> 1 & 1 == 1
+
+    @property
+    def lock_when_pluggedin(self):
+       """Lock when plugged in status"""
+       return self._data.get("lck", 0) >> 2 & 1 == 1
+
+    @property
+    def lock_when_unplugged(self):
+       """Lock when unplugged status"""
+       return self._data.get("lck", 0) >> 3 & 1 == 1
+
+    @property
+    def charge_when_locked(self):
+       """Charge when locked enabled"""
+       return self._data.get("lck", 0) >> 4 & 1 == 1

--- a/custom_components/myenergi/manifest.json
+++ b/custom_components/myenergi/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/cjne/ha-myenergi/issues",
   "requirements": ["pymyenergi==0.2.2"],
-  "version": "0.0.29"
+  "version": "0.0.29.1"
 }

--- a/custom_components/myenergi/sensor.py
+++ b/custom_components/myenergi/sensor.py
@@ -329,19 +329,19 @@ async def async_setup_entry(hass, entry, async_add_devices):
             for key in device.ct_keys:
                 sensors.append(MyenergiCTEnergySensor(coordinator, device, entry, key))
         # Zappi and harvi
-#        if device.kind in [ZAPPI, EDDI, HARVI]:
-#            sensors.append(
-#                MyenergiSensor(
-#                    coordinator,
-#                    device,
-#                    entry,
-#                    create_power_meta(
-#                        f"{device.ct3.name} CT3",
-#                        "ct3.power",
-#                        ENTITY_CATEGORY_DIAGNOSTIC,
-#                    ),
-#                )
-#            )
+        if device.kind in [ZAPPI, EDDI, HARVI]:
+            sensors.append(
+                MyenergiSensor(
+                    coordinator,
+                    device,
+                    entry,
+                    create_power_meta(
+                        f"{device.ct3.name} CT3",
+                        "ct3.power",
+                        ENTITY_CATEGORY_DIAGNOSTIC,
+                    ),
+                )
+            )
         # Zappi only sensors
         if device.kind == ZAPPI:
             sensors.append(

--- a/custom_components/myenergi/sensor.py
+++ b/custom_components/myenergi/sensor.py
@@ -329,19 +329,19 @@ async def async_setup_entry(hass, entry, async_add_devices):
             for key in device.ct_keys:
                 sensors.append(MyenergiCTEnergySensor(coordinator, device, entry, key))
         # Zappi and harvi
-        if device.kind in [ZAPPI, EDDI, HARVI]:
-            sensors.append(
-                MyenergiSensor(
-                    coordinator,
-                    device,
-                    entry,
-                    create_power_meta(
-                        f"{device.ct3.name} CT3",
-                        "ct3.power",
-                        ENTITY_CATEGORY_DIAGNOSTIC,
-                    ),
-                )
-            )
+#        if device.kind in [ZAPPI, EDDI, HARVI]:
+#            sensors.append(
+#                MyenergiSensor(
+#                    coordinator,
+#                    device,
+#                    entry,
+#                    create_power_meta(
+#                        f"{device.ct3.name} CT3",
+#                        "ct3.power",
+#                        ENTITY_CATEGORY_DIAGNOSTIC,
+#                    ),
+#                )
+#            )
         # Zappi only sensors
         if device.kind == ZAPPI:
             sensors.append(


### PR DESCRIPTION
Added sensors for lock statuses: Locked, Charge when locked, Lock when plugged, Lock when unplugged. 

Installed on my home assistant and working. 

Resolves lack of sensors mentioned in #323 
Edit: also resolves #95 
Edit: Squashed commits for legibility.