### PR TITLE
Fix deprecated

### DIFF
--- a/custom_components/myenergi/__init__.py
+++ b/custom_components/myenergi/__init__.py
@@ -11,7 +11,7 @@ from datetime import timedelta
 
 import homeassistant.util.dt as dt_util
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Config
+from homeassistant.core_config import Config
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.update_coordinator import UpdateFailed

--- a/custom_components/myenergi/entity.py
+++ b/custom_components/myenergi/entity.py
@@ -45,7 +45,6 @@ class MyenergiEntity(CoordinatorEntity):
             "name": self.device.name,
             "model": self.device.kind.capitalize(),
             "manufacturer": "myenergi",
-            "via_device": self.coordinator.client.serial_number,
             "sw_version": self.device.firmware_version,
         }
 


### PR DESCRIPTION
Fix `from homeassistant.core import Config` and `via_device` deprecated at startup