### PR TITLE
Fix max boost time Eddi

### DIFF
--- a/custom_components/myenergi/services.yaml
+++ b/custom_components/myenergi/services.yaml
@@ -39,7 +39,7 @@ myenergi_eddi_boost:
       selector:
         number:
           min: 1
-          max: 1440
+          max: 240
 myenergi_smart_boost:
   name: Smart boost
   description: Start smart boost


### PR DESCRIPTION
The maximum allowed boost time is 4 hours. It is theorized that a higher boost time will result in a boost time of 0 and thus deactivating the boost.