### PR TITLE
fix for issue #679 Updated config_flow.py to use self.config_entry instead of config_entry which breaks config flow in ha2025.12

### DIFF
--- a/custom_components/myenergi/services.yaml
+++ b/custom_components/myenergi/services.yaml
@@ -45,11 +45,9 @@ myenergi_smart_boost:
   description: Start smart boost
   target:
     device:
-      selector:
-        device:
-          model: Zappi
-        entity:
-          domain: select
+      model: Zappi
+    entity:
+      domain: select
   fields:
     amount:
       name: Amount
@@ -86,9 +84,7 @@ myenergi_libbi_charge_target:
   description: Set charge target for libbi
   target:
     device:
-      selector:
-        device:
-          model: Libbi
+      model: Libbi
   fields:
     chargetarget:
       name: Charge Target


### PR DESCRIPTION
fix for issue https://github.com/CJNE/ha-myenergi/issues/679 Updated config_flow.py to use self.config_entry instead of config_entry parameter of async_get_options_flow which was removed in ha 2025.12
https://developers.home-assistant.io/blog/2024/11/12/options-flow/?hl=en-US

With this change it works again in my homeassistant 2025.12.3installation.