### PR TITLE
Fix sensor permanently stuck unavailable after property returns None

### DIFF
--- a/custom_components/myenergi/sensor.py
+++ b/custom_components/myenergi/sensor.py
@@ -763,6 +763,7 @@ class MyenergiSensor(MyenergiEntity, SensorEntity):
         """Return the state of the sensor."""
         value = operator.attrgetter(self.meta["prop_name"])(self.device)
         if value is not None:
+            self._attr_available = True
             return value
         else:
             self._attr_available = False


### PR DESCRIPTION
## Summary

- When a device property (e.g. `charge_added` on Zappi) temporarily returns `None` between charging sessions, `_attr_available` is set to `False` in `MyenergiSensor.state`
- It is never reset to `True` when a valid value returns
- In modern HA, `CoordinatorEntity.available` returns `last_update_success AND _attr_available`, so the sensor becomes permanently unavailable until HA restarts
- This one-line fix resets `_attr_available = True` when a valid value is returned

Fixes #747

## Test plan

- [ ] Start a Zappi charging session, verify `charge_added_session` sensor is available and updating
- [ ] End the session so `charge_added` returns `None` — sensor should go unavailable
- [ ] Start a new session — sensor should recover to available without requiring HA restart
