### PR TITLE
fix: correct libbi charge target percentage calculation (resolves #727)

### DIFF
--- a/custom_components/myenergi/number.py
+++ b/custom_components/myenergi/number.py
@@ -8,6 +8,11 @@ from .entity import MyenergiEntity
 
 ENTITY_CATEGORY_CONFIG = EntityCategory.CONFIG
 
+# Libbi usable capacity is ~90.2% of reported mbc (accounts for hardware SoC reserve).
+# Confirmed: 10 kWh (mbc=10200) → 9200 Wh usable; 20 kWh (mbc=20400) → 18400 Wh usable.
+# Both ratios simplify to 92/102 (source: twonk/MyEnergi-App-Api + issue #727 data).
+LIBBI_USABLE_CAPACITY_FACTOR = 92 / 102
+
 
 async def async_setup_entry(hass, entry, async_add_devices):
     """Setup number platform."""
@@ -202,17 +207,17 @@ class TargetChargePercentSlider(MyenergiEntity, NumberEntity):
 
     @property
     def native_value(self):
-        """Return the current charge target as a percentage of battery capacity."""
-        if self.device.battery_size:
-            return int(
-                round(self.device.charge_target / self.device.battery_size * 100)
-            )
-        return 0
+        """Return the current charge target as a percentage of usable battery capacity."""
+        if self.device.battery_size and self.device.charge_target is not None:
+            usable_size = self.device.battery_size * LIBBI_USABLE_CAPACITY_FACTOR
+            return int(round(self.device.charge_target / usable_size * 100))
+        return None
 
     async def async_set_native_value(self, value: float) -> None:
-        """Set a new charge target percentage (converted to Wh)."""
+        """Set a new charge target percentage (converted to Wh using usable capacity)."""
         if self.device.battery_size:
-            target_wh = int((value / 100) * (self.device.battery_size * 1000))
+            usable_wh = self.device.battery_size * 1000 * LIBBI_USABLE_CAPACITY_FACTOR
+            target_wh = int(round((value / 100) * usable_wh))
             await self.device.set_charge_target(target_wh)
             self.async_schedule_update_ha_state()
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -45,10 +45,9 @@ async def setup_mock_myenergi_config_entry(
     data: dict[str, Any] | None = None,
     config_entry: ConfigEntry | None = None,
     client: Mock | None = None,
+    client_fixture: str | None = None,
 ) -> ConfigEntry:
-    client_data = "client"
-    if data is not None:
-        client_data = data.get("client_data", "client")
+    client_data = client_fixture or "client"
     """Add a mock sunspec config entry to hass."""
     config_entry = config_entry or create_mock_myenergi_config_entry(hass, data)
     """Mock data from client.fetch_data()"""
@@ -64,6 +63,9 @@ async def setup_mock_myenergi_config_entry(
         patch(
             "pymyenergi.eddi.Eddi.fetch_history_data",
             return_value=load_fixture_json("history_eddi"),
+        ),
+        patch(
+            "pymyenergi.libbi.Libbi.refresh_extra",
         ),
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,3 +166,10 @@ def mock_zappi_unlock():
     """Return a mocked Zappi object."""
     with patch("pymyenergi.client.Zappi.unlock") as unlock:
         yield unlock
+
+
+@pytest.fixture
+def mock_libbi_set_charge_target():
+    """Return a mocked Libbi set_charge_target."""
+    with patch("pymyenergi.client.Libbi.set_charge_target") as set_charge_target:
+        yield set_charge_target

--- a/tests/fixtures/client_libbi.json
+++ b/tests/fixtures/client_libbi.json
@@ -1,0 +1,34 @@
+{
+  "keys": {
+    "H1234": [
+      { "key": "L20000001", "val": "Test Libbi 1" },
+      { "key": "siteName", "val": "Test Site" }
+    ]
+  },
+  "devices": [
+    {
+      "libbi": [
+        {
+          "sno": 20000001,
+          "dat": "09-09-2023",
+          "tim": "10:00:00",
+          "sta": 5,
+          "lmo": "BALANCE",
+          "frq": 50.0,
+          "vol": 2400,
+          "soc": 65,
+          "pri": 1,
+          "mbc": 20400,
+          "mic": 5000,
+          "gen": 0,
+          "grd": 0,
+          "che": 0.0
+        }
+      ]
+    },
+    {
+      "asn": "s8.myenergi.net",
+      "fwv": "3401S3077"
+    }
+  ]
+}

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,4 +1,4 @@
-"""Test myenergi sensor."""
+"""Test myenergi number entities."""
 
 from unittest.mock import MagicMock, PropertyMock, patch
 
@@ -94,28 +94,43 @@ async def test_device_priority(
 
 async def test_libbi_charge_target_reads_100_percent(hass: HomeAssistant) -> None:
     """Verify charge target entity reads 100% when energyTarget = 18400 Wh (mbc=20400)."""
-    with patch.object(Libbi, "charge_target", new_callable=PropertyMock, return_value=18.4):
-        await setup_mock_myenergi_config_entry(hass, data={"client_data": "client_libbi"})
+    with patch.object(
+        Libbi, "charge_target", new_callable=PropertyMock, return_value=18.4
+    ):
+        await setup_mock_myenergi_config_entry(
+            hass, client_fixture="client_libbi"
+        )
 
-    entity_state = hass.states.get(TEST_LIBBI_NUMBER_CHARGE_TARGET)
-    assert entity_state
-    assert entity_state.state == "100"
+        entity_state = hass.states.get(TEST_LIBBI_NUMBER_CHARGE_TARGET)
+        assert entity_state
+        assert entity_state.state == "100"
 
 
 async def test_libbi_charge_target_reads_70_percent(hass: HomeAssistant) -> None:
     """Verify charge target entity reads 70% when energyTarget = 12880 Wh (mbc=20400)."""
-    with patch.object(Libbi, "charge_target", new_callable=PropertyMock, return_value=12.88):
-        await setup_mock_myenergi_config_entry(hass, data={"client_data": "client_libbi"})
+    with patch.object(
+        Libbi, "charge_target", new_callable=PropertyMock, return_value=12.88
+    ):
+        await setup_mock_myenergi_config_entry(
+            hass, client_fixture="client_libbi"
+        )
 
-    entity_state = hass.states.get(TEST_LIBBI_NUMBER_CHARGE_TARGET)
-    assert entity_state
-    assert entity_state.state == "70"
+        entity_state = hass.states.get(TEST_LIBBI_NUMBER_CHARGE_TARGET)
+        assert entity_state
+        assert entity_state.state == "70"
 
 
-async def test_libbi_charge_target_no_credentials_shows_unknown(hass: HomeAssistant) -> None:
-    """Verify charge target entity shows unknown state when app credentials are absent."""
-    with patch.object(Libbi, "charge_target", new_callable=PropertyMock, return_value=None):
-        await setup_mock_myenergi_config_entry(hass, data={"client_data": "client_libbi"})
+async def test_libbi_charge_target_no_credentials_shows_unknown(
+    hass: HomeAssistant,
+) -> None:
+    """Verify charge target entity shows unknown state when app credentials are absent.
+
+    MOCK_CONFIG has empty app_email/app_password, so the real Libbi.charge_target
+    property returns None without needing a mock.
+    """
+    await setup_mock_myenergi_config_entry(
+        hass, client_fixture="client_libbi"
+    )
 
     entity_state = hass.states.get(TEST_LIBBI_NUMBER_CHARGE_TARGET)
     assert entity_state
@@ -126,7 +141,12 @@ async def test_libbi_set_charge_target_70_percent(
     hass: HomeAssistant, mock_libbi_set_charge_target: MagicMock
 ) -> None:
     """Verify setting 70% sends 12880 Wh to the API (mbc=20400, usable=18400 Wh)."""
-    await setup_mock_myenergi_config_entry(hass, data={"client_data": "client_libbi"})
+    with patch.object(
+        Libbi, "charge_target", new_callable=PropertyMock, return_value=18.4
+    ):
+        await setup_mock_myenergi_config_entry(
+            hass, client_fixture="client_libbi"
+        )
 
     await hass.services.async_call(
         NUMBER_DOMAIN,
@@ -142,7 +162,12 @@ async def test_libbi_set_charge_target_100_percent(
     hass: HomeAssistant, mock_libbi_set_charge_target: MagicMock
 ) -> None:
     """Verify setting 100% sends 18400 Wh to the API (mbc=20400, usable=18400 Wh)."""
-    await setup_mock_myenergi_config_entry(hass, data={"client_data": "client_libbi"})
+    with patch.object(
+        Libbi, "charge_target", new_callable=PropertyMock, return_value=18.4
+    ):
+        await setup_mock_myenergi_config_entry(
+            hass, client_fixture="client_libbi"
+        )
 
     await hass.services.async_call(
         NUMBER_DOMAIN,

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,19 +1,22 @@
 """Test myenergi sensor."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
 from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
 from homeassistant.components.number import SERVICE_SET_VALUE
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
+from pymyenergi.libbi import Libbi
 
 from . import setup_mock_myenergi_config_entry
 
 TEST_ZAPPI_NUMBER_GREEN_LEVEL = "number.myenergi_test_zappi_1_minimum_green_level"
 TEST_EDDI_NUMBER_HEATER_PRIORITY = "number.myenergi_test_eddi_1_heater_priority"
 TEST_EDDI_NUMBER_DEVICE_PRIORITY = "number.myenergi_test_eddi_1_device_priority"
+TEST_LIBBI_NUMBER_CHARGE_TARGET = "number.myenergi_test_libbi_1_charge_target"
 
 
 async def test_number(hass: HomeAssistant, mock_zappi_set_green: MagicMock) -> None:
@@ -87,3 +90,65 @@ async def test_device_priority(
     await hass.async_block_till_done()
     assert mock_eddi_device.call_count == 1
     mock_eddi_device.assert_called_with(3)
+
+
+async def test_libbi_charge_target_reads_100_percent(hass: HomeAssistant) -> None:
+    """Verify charge target entity reads 100% when energyTarget = 18400 Wh (mbc=20400)."""
+    with patch.object(Libbi, "charge_target", new_callable=PropertyMock, return_value=18.4):
+        await setup_mock_myenergi_config_entry(hass, data={"client_data": "client_libbi"})
+
+    entity_state = hass.states.get(TEST_LIBBI_NUMBER_CHARGE_TARGET)
+    assert entity_state
+    assert entity_state.state == "100"
+
+
+async def test_libbi_charge_target_reads_70_percent(hass: HomeAssistant) -> None:
+    """Verify charge target entity reads 70% when energyTarget = 12880 Wh (mbc=20400)."""
+    with patch.object(Libbi, "charge_target", new_callable=PropertyMock, return_value=12.88):
+        await setup_mock_myenergi_config_entry(hass, data={"client_data": "client_libbi"})
+
+    entity_state = hass.states.get(TEST_LIBBI_NUMBER_CHARGE_TARGET)
+    assert entity_state
+    assert entity_state.state == "70"
+
+
+async def test_libbi_charge_target_no_credentials_shows_unknown(hass: HomeAssistant) -> None:
+    """Verify charge target entity shows unknown state when app credentials are absent."""
+    with patch.object(Libbi, "charge_target", new_callable=PropertyMock, return_value=None):
+        await setup_mock_myenergi_config_entry(hass, data={"client_data": "client_libbi"})
+
+    entity_state = hass.states.get(TEST_LIBBI_NUMBER_CHARGE_TARGET)
+    assert entity_state
+    assert entity_state.state == STATE_UNKNOWN
+
+
+async def test_libbi_set_charge_target_70_percent(
+    hass: HomeAssistant, mock_libbi_set_charge_target: MagicMock
+) -> None:
+    """Verify setting 70% sends 12880 Wh to the API (mbc=20400, usable=18400 Wh)."""
+    await setup_mock_myenergi_config_entry(hass, data={"client_data": "client_libbi"})
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: TEST_LIBBI_NUMBER_CHARGE_TARGET, "value": "70"},
+        blocking=False,
+    )
+    await hass.async_block_till_done()
+    mock_libbi_set_charge_target.assert_called_once_with(12880)
+
+
+async def test_libbi_set_charge_target_100_percent(
+    hass: HomeAssistant, mock_libbi_set_charge_target: MagicMock
+) -> None:
+    """Verify setting 100% sends 18400 Wh to the API (mbc=20400, usable=18400 Wh)."""
+    await setup_mock_myenergi_config_entry(hass, data={"client_data": "client_libbi"})
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: TEST_LIBBI_NUMBER_CHARGE_TARGET, "value": "100"},
+        blocking=False,
+    )
+    await hass.async_block_till_done()
+    mock_libbi_set_charge_target.assert_called_once_with(18400)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -40,7 +40,7 @@ async def test_sensor_power_import(hass: HomeAssistant) -> None:
 async def test_sensor_power_export(hass: HomeAssistant) -> None:
     """Verify device information includes expected details."""
 
-    await setup_mock_myenergi_config_entry(hass, {"client_data": "client_exporting"})
+    await setup_mock_myenergi_config_entry(hass, client_fixture="client_exporting")
 
     entity_state = hass.states.get(TEST_HUB_SENSOR_POWER_GRID_ENTITY_ID)
     entity_state_import = hass.states.get(TEST_HUB_SENSOR_POWER_IMPORT_ENTITY_ID)


### PR DESCRIPTION
## Summary

Fixes #727 — `number.myenergi_libbi_charge_target` shows a lower percentage than the myenergi app for the same setting (e.g. app shows 70%, HA shows ~63%).

## Root cause

`TargetChargePercentSlider` was dividing/multiplying by the full physical battery capacity (`mbc`), but the myenergi app uses the **usable capacity** which accounts for a hardware SoC reserve of ~9.8%.

## The fix

The usable capacity ratio is **92/102 ≈ 0.9020** — consistent across all Libbi variants:
- 10 kWh (mbc=10,200): 9,200 Wh usable → 9200/10200 = 92/102
- 20 kWh (mbc=20,400): 18,400 Wh usable → 18400/20400 = 92/102

Sources: [twonk/MyEnergi-App-Api](https://github.com/twonk/MyEnergi-App-Api) docs + field data from issue #727.

**Before fix (20 kWh battery, app set to 70%):**
- API returns `energyTarget = 12880` Wh
- HA displayed: `12.88 / 20.4 * 100 = 63%` ❌

**After fix:**
- HA displays: `12.88 / (20.4 * 0.9020) * 100 = 70%` ✅

## Changes

- **`custom_components/myenergi/number.py`**
  - Add `LIBBI_USABLE_CAPACITY_FACTOR = 92 / 102` constant (with explanation comment)
  - Fix `native_value`: divide by `battery_size × factor`; return `None` (not `0`) when `charge_target is None` so HA correctly shows `unknown` when app credentials are absent
  - Fix `async_set_native_value`: multiply by `battery_size * 1000 * factor`; use `round()` consistently

- **`tests/fixtures/client_libbi.json`** — new test fixture with `mbc=20400`
- **`tests/conftest.py`** — add `mock_libbi_set_charge_target` fixture
- **`tests/test_number.py`** — 5 new regression tests:
  - Read 100%: 18,400 Wh → 100 ✅
  - Read 70%: 12,880 Wh → 70 ✅
  - No credentials → `unknown` state ✅
  - Write 70% → 12,880 Wh sent to API ✅
  - Write 100% → 18,400 Wh sent to API ✅
