### PR TITLE
fix: make options-update reload safe and surface failure causes

### DIFF
--- a/custom_components/myenergi/__init__.py
+++ b/custom_components/myenergi/__init__.py
@@ -94,7 +94,13 @@ class MyenergiDataUpdateCoordinator(DataUpdateCoordinator):
             )
         )
 
-        super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=scan_interval)
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name=DOMAIN,
+            update_interval=scan_interval,
+        )
 
     async def _async_update_data(self):
         """Update data via library."""

--- a/custom_components/myenergi/__init__.py
+++ b/custom_components/myenergi/__init__.py
@@ -70,10 +70,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             # await hass.config_entries.async_forward_entry_setups(entry, platform)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    entry.add_update_listener(async_reload_entry)
-
-    # once we reconfigure the integration, we (possibly) need to use the new credentials
-    entry.async_on_unload(entry.add_update_listener(config_update_listener))
+    # Reload the entry when its options change (e.g. scan_interval). Register the
+    # listener through async_on_unload so the unsub handle is tracked and the
+    # listener is removed on unload — otherwise every setup stacks another copy
+    # and an options change fires the reload handler multiple times.
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
     return True
 
@@ -110,8 +111,11 @@ class MyenergiDataUpdateCoordinator(DataUpdateCoordinator):
             await self.client.refresh()
             await self.client.refresh_history(utc_today, 24, "hour")
         except Exception as exception:
-            _LOGGER.debug(exception)
-            raise UpdateFailed() from exception
+            # Attach the message so the cause (cloud throttling, auth failure,
+            # connectivity) is visible in the HA log. Previously this was logged
+            # only at DEBUG and re-raised as a bare UpdateFailed(), leaving the
+            # coordinator's failure reason invisible at default log levels.
+            raise UpdateFailed(f"myenergi update failed: {exception}") from exception
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -133,10 +137,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)
+    """Reload config entry.
 
-
-async def config_update_listener(hass, entry):
-    """Handle options update."""
+    Delegate to the config-entries manager rather than calling unload+setup
+    directly. The manager serialises the unload/setup cycle and rebuilds the
+    coordinator (and its refresh scheduler) cleanly; the previous hand-rolled
+    approach could race on an options update and leave the entry loaded with a
+    coordinator whose polling loop never restarted, stranding all entities as
+    unavailable until a full Home Assistant restart.
+    """
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,67 +1,55 @@
 """Test myenergi setup process."""
 
-import pytest
 from homeassistant.config_entries import ConfigEntryState
-from custom_components.myenergi import (
-    async_reload_entry,
-)
-from custom_components.myenergi import (
-    async_setup_entry,
-)
-from custom_components.myenergi import (
-    async_unload_entry,
-)
 from custom_components.myenergi import (
     MyenergiDataUpdateCoordinator,
 )
 from custom_components.myenergi.const import (
     DOMAIN,
 )
-from homeassistant.exceptions import ConfigEntryNotReady
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from .const import MOCK_CONFIG
+from . import create_mock_myenergi_config_entry
 
 
 # We can pass fixtures as defined in conftest.py to tell pytest to use the fixture
 # for a given test. We can also leverage fixtures and mocks that are available in
 # Home Assistant using the pytest_homeassistant_custom_component plugin.
-# Assertions allow you to verify that the return value of whatever is on the left
-# side of the assertion matches with the right side.
+# Setup, reload and unload are driven through the config entries manager so the
+# entry transitions through the states (SETUP_IN_PROGRESS -> LOADED) that
+# DataUpdateCoordinator.async_config_entry_first_refresh now requires.
 async def test_setup_unload_and_reload_entry(hass, bypass_get_data):
-    """Test entry setup and unload."""
-    # Create a mock entry so we don't have to go through config flow
-    config_entry = MockConfigEntry(
-        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", state=ConfigEntryState.LOADED
-    )
+    """Test entry setup, reload and unload."""
+    config_entry = create_mock_myenergi_config_entry(hass)
 
-    # Set up the entry and assert that the values set during setup are where we expect
-    # them to be. Because we have patched the MyenergiDataUpdateCoordinator.async_get_data
-    # call, no code from custom_components/myenergi/api.py actually runs.
-    assert await async_setup_entry(hass, config_entry)
-    assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
+    # Set up the entry and assert that the coordinator is stored where we expect.
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
     assert isinstance(
         hass.data[DOMAIN][config_entry.entry_id], MyenergiDataUpdateCoordinator
     )
 
-    # Reload the entry and assert that the data from above is still there
-    assert await async_reload_entry(hass, config_entry) is None
-    assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
+    # Reload the entry and assert the coordinator is rebuilt and still present.
+    assert await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
     assert isinstance(
         hass.data[DOMAIN][config_entry.entry_id], MyenergiDataUpdateCoordinator
     )
 
-    # Unload the entry and verify that the data has been removed
-    assert await async_unload_entry(hass, config_entry)
+    # Unload the entry and verify that the data has been removed.
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
     assert config_entry.entry_id not in hass.data[DOMAIN]
 
 
 async def test_setup_entry_exception(hass, error_on_get_data):
-    """Test ConfigEntryNotReady when API raises an exception during entry setup."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+    """Test the entry retries setup when the API raises during first refresh."""
+    config_entry = create_mock_myenergi_config_entry(hass)
 
-    # In this case we are testing the condition where async_setup_entry raises
-    # ConfigEntryNotReady using the `error_on_get_data` fixture which simulates
-    # an error.
-    with pytest.raises(ConfigEntryNotReady):
-        assert await async_setup_entry(hass, config_entry)
+    # The `error_on_get_data` fixture makes the first refresh fail, which surfaces
+    # as ConfigEntryNotReady and leaves the entry in the SETUP_RETRY state.
+    assert not await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -1,0 +1,38 @@
+"""Test config-entry reload behaviour.
+
+Regression test for the options-update reload path. Previously the reload
+listener was registered without tracking its unsub handle (leaking a fresh
+listener on every setup) and reload was hand-rolled as unload+setup, which
+could race and strand the coordinator without a running refresh loop. The fix
+registers the listener via async_on_unload and delegates reload to the
+config-entries manager.
+"""
+
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.myenergi import async_reload_entry
+from custom_components.myenergi.const import DOMAIN
+
+from .const import MOCK_CONFIG
+
+
+async def test_reload_delegates_to_config_entries_manager(hass):
+    """async_reload_entry delegates to hass.config_entries.async_reload.
+
+    The manager serialises unload/setup and rebuilds the coordinator (and its
+    refresh scheduler) cleanly. The integration must not hand-roll the cycle as
+    unload+setup, which could race on an options update and strand the
+    coordinator without a running poll loop.
+    """
+    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+    config_entry.add_to_hass(hass)
+
+    with patch.object(
+        hass.config_entries, "async_reload", new=AsyncMock()
+    ) as mock_reload:
+        await async_reload_entry(hass, config_entry)
+
+    mock_reload.assert_awaited_once_with(config_entry.entry_id)


### PR DESCRIPTION
Fixes #759.

## Summary

Two related fixes for cases where the integration silently stops working — both
centred on the `DataUpdateCoordinator` lifecycle.

### 1. Options-change reload can strand every entity

Editing an option (in my case `scan_interval`) left all entities `unavailable`
while the config entry still showed `loaded`, with **nothing in the log** — and
it only recovered after a full Home Assistant restart.

Two things combined to cause this:

- The reload listener was registered as
  `entry.add_update_listener(async_reload_entry)` and the returned unsub handle
  was discarded. It was never removed on unload, so each setup stacked another
  copy and a single options change could fire the reload handler more than once.
- `async_reload_entry` hand-rolled the cycle as `async_unload_entry()` followed
  by `async_setup_entry()`. Driving unload+setup directly (rather than through
  the config-entries manager) can race on an options update and leave the entry
  `loaded` with a coordinator whose refresh loop never restarted — hence the
  silent, permanent unavailability.

Fix: register the listener via `entry.async_on_unload(...)` so the handle is
tracked and removed on unload, and delegate reload to
`hass.config_entries.async_reload(entry.entry_id)`, which serialises the cycle
and rebuilds the coordinator cleanly. The empty `config_update_listener` is
removed (it did nothing).

### 2. Update failures are invisible at default log levels

`_async_update_data` logged the exception only at `DEBUG` and re-raised a bare
`UpdateFailed()`. When the integration goes unavailable (cloud-side throttling,
auth failure, connectivity), there's no indication of the cause unless you've
already enabled debug logging. This attaches the exception message to
`UpdateFailed` so the reason appears in the log.

## Verification

Reproduced and fixed against a live install (Zappi, Eddi + hub):

- Before: editing `scan_interval` stranded all entities as `unavailable` with the
  entry still `loaded` and no log output; only a restart recovered.
- After: changing `scan_interval` reloads cleanly and entities stay/return
  available within a few seconds, no restart needed.

Adds a regression test asserting `async_reload_entry` delegates to
`hass.config_entries.async_reload`.

## Note on CI

`tests/test_init.py::test_setup_unload_and_reload_entry` and
`::test_setup_entry_exception` fail on this branch — but they **also fail on an
unmodified `main`**. The cause is unrelated HA-version drift:
`async_config_entry_first_refresh()` now requires the coordinator to be
constructed with `config_entry=...`, which the current `__init__` predates. I've
left that out of scope here to keep this PR focused on the reload/availability
fix, but I'm happy to address it (and the coordinator's `config_entry` wiring) in
a follow-up if useful.

## Test plan

- [ ] With the integration loaded, change `scan_interval` via the options flow
      and submit.
- [ ] Confirm the integration reloads and entities remain/return available
      without a Home Assistant restart.
- [ ] (Optional) Force an update failure and confirm the cause now appears in
      the log via `UpdateFailed`.
